### PR TITLE
Fix/preamble path

### DIFF
--- a/src/api/compose.javascript.ts
+++ b/src/api/compose.javascript.ts
@@ -34,15 +34,42 @@ class Javascript extends Language {
         }
         return false;
     }
-    require = function(path) {
+    getAbsolutePath = function (base, relative) {
+        var base = base.split("/")
+        base.pop()
+        var baseLength = base.length;
+        var relative = relative.split("/")
+        var result = []
+        
+        while(relative.length != 0){
+            var sub = relative.pop()
+            if(sub == ".")
+                continue
+            if(sub == ".."){
+                result.push(base.pop())
+            }
+            else{
+                result.push(sub)
+            }
+        }
+        result[0] += (result[0].indexOf(".") !== -1)?"":".js"
+        if(result[result.length-1] !== base[0]){
+            while(base.length != 0)
+                result.push(base.pop())
+        }
+        return result.reverse().join("/")
+    }
+    require = function(parentPath){ return function(path) {
+        
         if (module_cache[path]) {
             return module_cache[path].exports;
         }
+        path = getAbsolutePath(parentPath,path)
         module_path = find_module(path)
         if (module_path)
         {
             var module = module_cache[module_path] = {exports: {}};
-            modules[module_path].call(module.exports, module, module.exports, require);
+            modules[module_path].call(module.exports, module, module.exports, require(module_path));
         }
         else
         {
@@ -50,18 +77,18 @@ class Javascript extends Language {
         }
         return module.exports;
     }
-    main = require('${filelist[filelist.length - 1]}');
+  }
+    main = require('${filelist[filelist.length - 1]}')('${
+      filelist[filelist.length - 1].split('.')[0]
+    }');
     require = builtin_require;
     return main;
 })(require, {`;
     for (const filename of filelist) {
-      const modname = filename
-        .split('/')
-        .slice(-1)
-        .join('/');
+      const modkey = filename;
       const contentWrapper = [
         `
-    '${modname}': (function(module, exports, require) {
+    '${modkey}': (function(module, exports, require) {
 ${this.comment}${this.getBeginGuard()} ${filename}\n`,
         `
 ${this.comment}${this.getEndGuard()} ${filename}

--- a/src/api/compose.utils.ts
+++ b/src/api/compose.utils.ts
@@ -40,11 +40,10 @@ export const compose = (
         .getData()
         .toString('utf-8')
         .split('\r')
-        .join("")
-        .split("\n");
+        .join('')
+        .split('\n');
       return acc;
     }, {});
-  
 
   const filenames: string[] = filterFiles(
     files,
@@ -94,33 +93,36 @@ export const findModule = (
   return false;
 };
 
-const getAbsolutePath =  (parent:string, subdir:string, language:Language) => {
-  const base = parent.split("/")
-  const relative = subdir.split("/")
-  const result:string[] = []
-  
-  base.pop()
+export const getAbsolutePath = (
+  parent: string,
+  subdir: string,
+  language: Language
+) => {
+  const base = parent.split('/');
+  const relative = subdir.split('/');
+  const result: string[] = [];
 
-  while(relative.length !== 0){
-      const sub = relative.pop()
-      if(sub === "."){
-          continue
-      }
-      if(sub === ".."){
-          result.push(base.pop() as string)
-      }
-      else{
-          result.push(sub as string)
-      }
+  base.pop();
+
+  while (relative.length !== 0) {
+    const sub = relative.pop();
+    if (sub === '.') {
+      continue;
+    }
+    if (sub === '..') {
+      result.push(base.pop() as string);
+    } else {
+      result.push(sub as string);
+    }
   }
-  result[0] += (result[0].indexOf(".") !== -1)?"":language.getExtensions()[0]
-  if(result[result.length-1] !== base[0]){
-      while(base.length !== 0){
-          result.push(base.pop() as string)
-      }
+  result[0] += result[0].indexOf('.') !== -1 ? '' : language.getExtensions()[0];
+  if (result[result.length - 1] !== base[0]) {
+    while (base.length !== 0) {
+      result.push(base.pop() as string);
+    }
   }
-  return result.reverse().join("/")
-}
+  return result.reverse().join('/');
+};
 
 /**
  * Recursively filters a project file list down to those that are dependancies of the main file
@@ -142,7 +144,7 @@ export const filterFiles = (
     for (const reg of regex) {
       const re = reg;
       const m = re.exec(line);
-      
+
       if (m !== null) {
         const requireName = findModule(
           getAbsolutePath(entryPoint, m[2], curlang),

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -49,10 +49,7 @@
                             var entryName = entry.filename.split('/').pop()
                             acc += `<li id="${
                                 entryName
-                            }" data-jstree='{"icon":"material-icons tiny"}'><a href="#" onclick="setEntry(this, '${entry.filename
-                            .split('/')
-                            .slice(1)
-                            .join('/')}')">${entryName}</a></li>`;
+                            }" data-jstree='{"icon":"material-icons tiny"}'><a href="#" onclick="setEntry(this, '${entry.filename}')">${entryName}</a></li>`;
                         }
                         return acc;
 

--- a/test/api/filterFiles.test.ts
+++ b/test/api/filterFiles.test.ts
@@ -8,7 +8,7 @@ const jsfiles1: {[index: string]: string[]} ={
 	"file4/index.js" : ["require('file6')", "console.log('Help')"]
 };
 
-const jsfilesout1 = [ 'file3.js', 'file4/index.js', 'file2', 'file1' ]
+const jsfilesout1 = [ 'file3.js', 'file1' ]
 
 
 const jsregex = [/require\((['"])([^'"]+)\1\)/]
@@ -21,16 +21,16 @@ const jsfiles2: {[index: string]: string[]} ={
 	file5 : ["require('file3')", "console.log('Im')"],
 };
 
-const jsfilesout2 = [ 'file3.js', 'file5', 'file4/index.js', 'file2', 'file1' ]
+const jsfilesout2 = [ 'file3.js', 'file1' ];
 
 test("Filter files did not return expected output for javascript1", () =>
 	{
 		expect(filterFiles(jsfiles1, javascript, "file1", jsregex)).toMatchObject(jsfilesout1)
 	}
-)
+);
 
 test("filterFiles did not return expected output for javascript2", () =>
 	{
 		expect(filterFiles(jsfiles2, javascript, "file1", jsregex)).toMatchObject(jsfilesout2)
 	}
-)
+);

--- a/test/api/getAbsolutePath.test.ts
+++ b/test/api/getAbsolutePath.test.ts
@@ -1,0 +1,11 @@
+import { getAbsolutePath } from "../../src/api/compose.utils";
+import {javascript} from "../../src/api/compose.javascript"
+
+
+
+test("getAbsolutePath returns relative path off base",()=>{
+    expect(getAbsolutePath("/main/test.js","../stuff.js",javascript))
+    expect(getAbsolutePath("/main/test.js","./stuff",javascript))
+    expect(getAbsolutePath("/main/test.js","../sub/stuff",javascript))
+    expect(getAbsolutePath("/main/test.js","/test",javascript))
+})


### PR DESCRIPTION
The require method that replaces the builtin one now is a function that returns a require/closure with a context that includes the path to the parent. Absolute path then replaces any "../" with the correct part of the parent path.