### PR TITLE
Fix/python tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 | Statements | Branches | Functions | Lines |
 | -----------|----------|-----------|-------|
-| ![Statements](https://img.shields.io/badge/Coverage-99.15%25-brightgreen.svg ) | ![Branches](https://img.shields.io/badge/Coverage-96.61%25-brightgreen.svg ) | ![Functions](https://img.shields.io/badge/Coverage-100%25-brightgreen.svg ) | ![Lines](https://img.shields.io/badge/Coverage-99.14%25-brightgreen.svg ) |
+| ![Statements](https://img.shields.io/badge/Coverage-99.15%25-brightgreen.svg ) | ![Branches](https://img.shields.io/badge/Coverage-96.61%25-brightgreen.svg ) | ![Functions](https://img.shields.io/badge/Coverage-100%25-brightgreen.svg ) | ![Lines](https://img.shields.io/badge/Coverage-99.15%25-brightgreen.svg ) |
 
 # COMPOSE
 

--- a/src/api/language.ts
+++ b/src/api/language.ts
@@ -33,6 +33,14 @@ export abstract class Language implements Composable {
   }
 
   /**
+   * Name of language from language package
+   * @returns name of language in lowercase
+   */
+  processLine(line: string): string {
+    return line;
+  }
+
+  /**
    * Verfies if extension is valid based on Language Package. Returns True if extension is valid, else False
    */
   isValidExt(ext: string): boolean {

--- a/src/api/language.ts
+++ b/src/api/language.ts
@@ -34,6 +34,7 @@ export abstract class Language implements Composable {
 
   /**
    * Called in revert to undo any processing done to the line during compose
+   * @param line string, line of the program
    * @returns default returns the same line, sub classes can override
    */
   processLine(line: string): string {

--- a/src/api/language.ts
+++ b/src/api/language.ts
@@ -33,8 +33,8 @@ export abstract class Language implements Composable {
   }
 
   /**
-   * Name of language from language package
-   * @returns name of language in lowercase
+   * Called in revert to undo any processing done to the line during compose
+   * @returns default returns the same line, sub classes can override
    */
   processLine(line: string): string {
     return line;

--- a/src/api/python.ts
+++ b/src/api/python.ts
@@ -95,6 +95,9 @@ def modulize(module_name, dependencies=[]):
     }
     return combined;
   }
+  processLine(line: string): string {
+    return line.slice(4);
+  }
 }
 
 export const python = new Python();

--- a/src/api/python.ts
+++ b/src/api/python.ts
@@ -95,6 +95,12 @@ def modulize(module_name, dependencies=[]):
     }
     return combined;
   }
+
+  /**
+   * Undoes per line modification by the python compose method
+   * @param line of the composed file
+   * @returns line minus the 4 spaces add by python compose
+   */
   processLine(line: string): string {
     return line.slice(4);
   }

--- a/src/api/revert.ts
+++ b/src/api/revert.ts
@@ -96,7 +96,11 @@ export const revert = (file: Buffer, language: string): Buffer => {
         mockdir,
         mockdir['/']
       );
-      dirObj[dir.split('/').slice(-1)[0]] = lines.slice(begin, end).join(EOL);
+
+      dirObj[dir.split('/').slice(-1)[0]] = lines
+        .slice(begin, end)
+        .map(languageInstance.processLine)
+        .join(EOL);
     });
 
   const dirs = {};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -21,7 +21,7 @@ const upload: multer.Instance = multer({
     const acceptedMimeTypes: string[] = [
       'application/x-zip-compressed',
       'application/zip',
-      'text/plain'
+      'text/plain',
     ];
     acceptedMimeTypes.push(...acceptedLanguages);
     cb(null, acceptedMimeTypes.includes(file.mimetype));

--- a/test/api/language.test.ts
+++ b/test/api/language.test.ts
@@ -31,3 +31,7 @@ test(`${exts[0]} is a valid extension`, ()=>{
 test(`.nope is not a valid extension`, ()=>{
     expect(languageInstance.isValidExt(".nope")).toBe(false);
 })
+
+test(`Langauge default process line`, ()=>{
+  expect(languageInstance.processLine("test")).toEqual("test")
+})

--- a/test/api/python.test.ts
+++ b/test/api/python.test.ts
@@ -36,6 +36,9 @@ test(`is ${name} a language`,()=>{
     expect(language).toBeInstanceOf(Language);
 })
 
+test(`${name} process lines returns a string with 4 less leading spaces`, ()=>{
+    expect(language.processLine("    test")).toEqual("test")
+})
 
 test(`is ${name} composable`,()=>{
 


### PR DESCRIPTION
added method to top level Langauge class, languages overrride it to add processing per line in the revert function.... Python was not reverting correctly because of modules being tabbed over into function definitions.